### PR TITLE
Strip whitespace from vappid

### DIFF
--- a/lib/vagrant-vcloudair.rb
+++ b/lib/vagrant-vcloudair.rb
@@ -54,7 +54,7 @@ module Vagrant
     def get_vapp_id
       vappid_file = @data_dir.join('../../../vcloudair_vappid')
       if vappid_file.file?
-        @vappid = vappid_file.read
+        @vappid = vappid_file.read.chomp
       else
         nil
       end


### PR DESCRIPTION
When reading the vappid from a file strip any leading or trailing whitespace
so that the URL can be constructed correctly.
